### PR TITLE
Focus on clicked footprint

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,6 +359,8 @@ If the values and attributes do not exactly match one definite choice (for a var
 
 In case the defined variation rules cannot be parsed without problems, an error message window with a list of problems will appear.  Each of these problems must then be fixed in order to successfully start the plugin.
 
+In KiCad 7.99 Nightlies from around 2023-10-18, clicking an item in the error list focuses the corresponding footprint in the pcbnew canvas.
+
 #### Variation Choices Selection
 
 If all rules can be parsed without problems, the main dialog window appears.
@@ -369,7 +371,7 @@ For the above [real-world examples](#real-world-examples), the selection dialog 
 
 For each of the listed variation aspects a variation choice can now be selected.  If the values and attributes of the footprint(s) related to a variation aspect shall not be modified, the entry _'\<unset>'_ can be selected for that variation aspect.  In this case, the corresponding variation is skipped during the assignment stage and related footprints remain unmodified.
 
-The text section below the selection area summarizes all component value and attribute changes to be performed for each related footprint if the current variation configuration is applied.
+The change list section below the selection area summarizes all component value and attribute changes to be performed for each related footprint if the current variation configuration is applied.  In KiCad 7.99 Nightlies from around 2023-10-18, clicking an item in the change list focuses the corresponding footprint in the pcbnew canvas.
 
 After selecting a few different variation choices, the dialog window may look like the following:
 

--- a/plugin/kivar.py
+++ b/plugin/kivar.py
@@ -1,5 +1,6 @@
 import pcbnew
 import wx
+import wx.lib.agw.hyperlink as hyperlink
 from os import path as os_path
 
 # Used abbreviations:
@@ -28,10 +29,12 @@ class VariantPlugin(pcbnew.ActionPlugin):
     def Run(self):
         board = pcbnew.GetBoard()
         vn_dict, errors = get_vn_dict(board)
-        if len(errors) == 0:
-            ShowVariantDialog(board, vn_dict)
+        if len(errors) > 0:
+            ShowErrorDialog('Rule errors', errors, board)
+        elif len(vn_dict) == 0:
+            ShowMissingRulesDialog()
         else:
-            ShowErrorDialog('Rule errors', errors)
+            ShowVariantDialog(board, vn_dict)
 
 def wrap_HasField(fp, field):
     if pcbnew_version() >= 799:
@@ -44,6 +47,11 @@ def wrap_GetField(fp, field):
         return fp.GetFieldByName(field).GetText()
     else:
         return fp.GetProperty(field)
+
+def wrap_FocusOnItem(item):
+    if pcbnew_version() >= 799:
+        return pcbnew.FocusOnItem(item)
+    # not supported on earlier versions
 
 def pcbnew_version():
     return int(pcbnew.GetMajorMinorPatchVersion().split('.')[0]) * 100 + int(pcbnew.GetMajorMinorPatchVersion().split('.')[1])
@@ -58,7 +66,7 @@ def variant_cfg_field_name():
     return 'KiVar.Rule'
 
 def help_url():
-    return 'https://github.com/markh-de/KiVar'
+    return 'https://github.com/markh-de/KiVar#usage'
 
 def opt_dnp():
     return 'dnp'
@@ -101,6 +109,7 @@ def detect_current_choices(board, vn_dict):
     for ref in vn_dict:
         fp = board.FindFootprintByReference(ref) # TODO error handling! can return "None"
         fp_value = fp.GetValue()
+
         if use_attr_excl_from_bom():
             fp_excl_bom = fp.IsExcludedFromBOM()
         if use_attr_excl_from_posfiles():
@@ -116,7 +125,7 @@ def detect_current_choices(board, vn_dict):
                 fp_choice_dnp = opt_dnp() in vn_dict[ref][vn][choice][key_opts()]
                 eliminate = False
 
-                if fp_choice_value != None:
+                if fp_choice_value is not None:
                     if fp_value != fp_choice_value:
                         eliminate = True
 
@@ -165,7 +174,7 @@ def detect_current_choices(board, vn_dict):
                 new_value = vn_dict[ref][vn][selected_choice][key_val()]
                 new_dnp = opt_dnp() in vn_dict[ref][vn][selected_choice][key_opts()]
                 mismatch = False
-                if new_value != None:
+                if new_value is not None:
                     if fp_value != new_value:
                         mismatch = True
                 if use_attr_excl_from_bom():
@@ -194,29 +203,29 @@ def apply_choices(board, vn_dict, selection, dry_run = False):
             if selected_choice != '': # None?
                 vn_text = f'{vn}.{selected_choice}'
                 new_value = vn_dict[ref][vn][selected_choice][key_val()]
-                if new_value != None:
+                if new_value is not None:
                     old_value = fp.GetValue()
                     if old_value != new_value:
-                        changes.append(f"Change {ref} value from '{old_value}' to '{new_value}' ({vn_text}).")
+                        changes.append([ref, f"Change {ref} value from '{old_value}' to '{new_value}' ({vn_text})."])
                         if not dry_run:
                             fp.SetValue(new_value)
                 new_dnp = opt_dnp() in vn_dict[ref][vn][selected_choice][key_opts()]
                 if use_attr_dnp():
                     old_dnp = fp.IsDNP()
                     if old_dnp != new_dnp:
-                        changes.append(f"Change {ref} 'Do not populate' from '{bool_as_text(old_dnp)}' to '{bool_as_text(new_dnp)}' ({vn_text}).")
+                        changes.append([ref, f"Change {ref} 'Do not populate' from '{bool_as_text(old_dnp)}' to '{bool_as_text(new_dnp)}' ({vn_text})."])
                         if not dry_run:
                             fp.SetDNP(new_dnp)
                 if use_attr_excl_from_bom():
                     old_excl_from_bom = fp.IsExcludedFromBOM()
                     if old_excl_from_bom != new_dnp:
-                        changes.append(f"Change {ref} 'Exclude from bill of materials' from '{bool_as_text(old_excl_from_bom)}' to '{bool_as_text(new_dnp)}' ({vn_text}).")
+                        changes.append([ref, f"Change {ref} 'Exclude from bill of materials' from '{bool_as_text(old_excl_from_bom)}' to '{bool_as_text(new_dnp)}' ({vn_text})."])
                         if not dry_run:
                             fp.SetExcludedFromBOM(new_dnp)
                 if use_attr_excl_from_posfiles():
                     old_excl_from_posfiles = fp.IsExcludedFromPosFiles()
                     if old_excl_from_posfiles != new_dnp:
-                        changes.append(f"Change {ref} 'Exclude from position files' from '{bool_as_text(old_excl_from_posfiles)}' to '{bool_as_text(new_dnp)}' ({vn_text}).")
+                        changes.append([ref, f"Change {ref} 'Exclude from position files' from '{bool_as_text(old_excl_from_posfiles)}' to '{bool_as_text(new_dnp)}' ({vn_text})."])
                         if not dry_run:
                             fp.SetExcludedFromPosFiles(new_dnp)
     return changes
@@ -234,7 +243,7 @@ def get_vn_dict(board):
         ref = fp.GetReference()
         if wrap_HasField(fp, vn_field_name):
             if ref in vns:
-                errors.append(f"{ref}: Multiple footprints with same reference containing a rule definition field '{vn_field_name}'.")
+                errors.append([ref, f"{ref}: Multiple footprints with same reference containing a rule definition field '{vn_field_name}'."])
                 continue
 
             vns[ref] = {}
@@ -247,11 +256,11 @@ def get_vn_dict(board):
             try:
                 vn_def = split_ruledef(field_value, ',', False)
             except Exception as e:
-                errors.append(f"{ref}: Rule parser error: {str(e)}.")
+                errors.append([ref, f"{ref}: Rule parser error: {str(e)}."])
                 continue
 
             if len(vn_def) < 2:
-                errors.append(f"{ref}: Invalid number of elements in rule definition field '{vn_field_name}'.")
+                errors.append([ref, f"{ref}: Invalid number of elements in rule definition field '{vn_field_name}'."])
                 continue
 
             section_is_vn = True
@@ -262,10 +271,10 @@ def get_vn_dict(board):
                     try:
                         parts = split_ruledef(section, ' ', True)
                     except Exception as e:
-                        errors.append(f"{ref}: Variation name parser error: {str(e)}.")
+                        errors.append([ref, f"{ref}: Variation name parser error: {str(e)}."])
                         continue
                     if len(parts) != 1:
-                        errors.append(f"{ref}: Variation name is not exactly one word.")
+                        errors.append([ref, f"{ref}: Variation name is not exactly one word."])
                         continue
                     vn = cook_raw_string(parts[0])
                     if not vn in vns[ref]:
@@ -276,14 +285,14 @@ def get_vn_dict(board):
                     try:
                         parts = split_ruledef(section, ':', False)
                     except Exception as e:
-                        errors.append(f"{ref}: Choice parser error: {str(e)}.")
+                        errors.append([ref, f"{ref}: Choice parser error: {str(e)}."])
                         continue
 
                     if len(parts) == 0:
-                        errors.append(f"{ref}: Empty choice definition.")
+                        errors.append([ref, f"{ref}: Empty choice definition."])
                         continue
                     elif len(parts) > 2:
-                        errors.append(f"{ref}: Choice definition has more than two parts.")
+                        errors.append([ref, f"{ref}: Choice definition has more than two parts."])
                         continue
 
                     if len(parts) == 1: # default choice definition
@@ -294,13 +303,13 @@ def get_vn_dict(board):
                         try:
                             choice_list = split_ruledef(parts[0], ' ', True)
                         except Exception as e:
-                            errors.append(f"{ref}: Choice names parser error: {str(e)}.")
+                            errors.append([ref, f"{ref}: Choice names parser error: {str(e)}."])
                             continue
 
                     try:
                         raw_args = split_ruledef(parts[args_part_idx], ' ', True)
                     except Exception as e:
-                        errors.append(f"{ref}: Choice arguments parser error: {str(e)}.")
+                        errors.append([ref, f"{ref}: Choice arguments parser error: {str(e)}."])
                         continue
 
                     choices = []
@@ -315,67 +324,61 @@ def get_vn_dict(board):
                         if raw_arg.startswith('-'): # not supposed to match if arg starts with '\-' or '"-'
                             option = arg[1:]
                             if not option in accepted_options:
-                                errors.append(f"{ref}: Unknown or invalid option '{option}'.")
+                                errors.append([ref, f"{ref}: Unknown or invalid option '{option}'."])
                                 continue
                             options.append(option)
                         else:
                             values.append(arg)
 
                     if len(values) > 1:
-                        errors.append(f"{ref}: More than one value assigned inside a choice definition.") # TODO add info in which choice def (index value)
+                        errors.append([ref, f"{ref}: More than one value assigned inside a choice definition."]) # TODO add info in which choice def (index value)
                         continue
                     else:
                         for choice in choices:
                             if choice in vns[ref][vn]:
                                 if len(parts) == 1:
-                                    errors.append(f"{ref}: Rule contains more than one default choice definition.")
+                                    errors.append([ref, f"{ref}: Rule contains more than one default choice definition."])
                                 else:
-                                    errors.append(f"{ref}: Choice '{choice}' is defined more than once inside the rule definition.")
+                                    errors.append([ref, f"{ref}: Choice '{choice}' is defined more than once inside the rule definition."])
                                 continue
                             vns[ref][vn][choice] = {}
                             vns[ref][vn][choice][key_val()] = values[0] if len(values) > 0 else None
                             vns[ref][vn][choice][key_opts()] = options
 
-    if len(vns) == 0:
-        errors.append('No rule definitions found.')
-        errors.append('')
-        errors.append('Please read the documentation to learn how to assign variation rules to symbols/footprints:')
-        errors.append(help_url())
-    else:
-        # Now check that each choice of each variation is defined for each reference.
-        # Also, flatten the dict, i.e. assign default values and options to specific choices.
-        choices = get_choice_dict(vns)
-        for ref in vns:
-            for vn in vns[ref]:
-                choices_with_value_defined = 0
-                for choice in choices[vn]:
-                    if choice in vns[ref][vn]: # TODO check that each choice is contained exactly ONCE in vns!
-                        if vns[ref][vn][choice][key_val()] == None:
-                            # There is a specific choice definition, but it does not contain a value.
-                            # Take the value from the default choice (if it exists), keep the options
-                            # as defined in the specific choice definition.
-                            if key_default() in vns[ref][vn]:
-                                vns[ref][vn][choice][key_val()] = vns[ref][vn][key_default()][key_val()]
-                    else:
-                        # The specific choice definition is missing. Copy value and options from default
-                        # choice definition (if it exists).
+    # Now check that each choice of each variation is defined for each reference.
+    # Also, flatten the dict, i.e. assign default values and options to specific choices.
+    choices = get_choice_dict(vns)
+    for ref in vns:
+        for vn in vns[ref]:
+            choices_with_value_defined = 0
+            for choice in choices[vn]:
+                if choice in vns[ref][vn]: # TODO check that each choice is contained exactly ONCE in vns!
+                    if vns[ref][vn][choice][key_val()] is None:
+                        # There is a specific choice definition, but it does not contain a value.
+                        # Take the value from the default choice (if it exists), keep the options
+                        # as defined in the specific choice definition.
                         if key_default() in vns[ref][vn]:
-                            vns[ref][vn][choice] = {}
                             vns[ref][vn][choice][key_val()] = vns[ref][vn][key_default()][key_val()]
-                            vns[ref][vn][choice][key_opts()] = vns[ref][vn][key_default()][key_opts()]
-                        else:
-                            vns[ref][vn][choice] = {}
-                            vns[ref][vn][choice][key_val()] = None
-                            vns[ref][vn][choice][key_opts()] = []
+                else:
+                    # The specific choice definition is missing. Copy value and options from default
+                    # choice definition (if it exists).
+                    if key_default() in vns[ref][vn]:
+                        vns[ref][vn][choice] = {}
+                        vns[ref][vn][choice][key_val()] = vns[ref][vn][key_default()][key_val()]
+                        vns[ref][vn][choice][key_opts()] = vns[ref][vn][key_default()][key_opts()]
+                    else:
+                        vns[ref][vn][choice] = {}
+                        vns[ref][vn][choice][key_val()] = None
+                        vns[ref][vn][choice][key_opts()] = []
 
-                    if vns[ref][vn][choice][key_val()] != None:
-                        choices_with_value_defined += 1
+                if vns[ref][vn][choice][key_val()] is not None:
+                    choices_with_value_defined += 1
 
-                if not (choices_with_value_defined == 0 or choices_with_value_defined == len(choices[vn])):
-                    errors.append(f"{ref}: Rule mixes choices with defined ({choices_with_value_defined}) and undefined ({len(choices[vn]) - choices_with_value_defined}) values (either all or none must be defined).")
-                    continue
+            if not (choices_with_value_defined == 0 or choices_with_value_defined == len(choices[vn])):
+                errors.append([ref, f"{ref}: Rule mixes choices with defined ({choices_with_value_defined}) and undefined ({len(choices[vn]) - choices_with_value_defined}) values (either all or none must be defined)."])
+                continue
 
-                vns[ref][vn].pop(key_default(), None) # clean-up temporary data: remove default choice data
+            vns[ref][vn].pop(key_default(), None) # clean-up temporary data: remove default choice data
 
     return vns, errors
 
@@ -450,7 +453,7 @@ def ShowVariantDialog(board, vn_dict):
 
 class VariantDialog(wx.Dialog):
     def __init__(self, board, vn_dict):
-        super(VariantDialog, self).__init__(pcbnew_parent_window(), title=f'KiVar {version()}: Variant Selection', style=wx.DEFAULT_DIALOG_STYLE | wx.RESIZE_BORDER)
+        super().__init__(pcbnew_parent_window(), title=f'KiVar {version()}: Variant Selection', style=wx.DEFAULT_DIALOG_STYLE | wx.RESIZE_BORDER)
 
         self.board = board
         self.vn_dict = vn_dict
@@ -481,7 +484,7 @@ class VariantDialog(wx.Dialog):
             self.choices[cfg].SetSelection(sel_index)
             self.choices[cfg].Bind(wx.EVT_CHOICE, self.on_change)
             
-            var_grid.Add(wx.StaticText(self, label=f'{cfg}:'), 1, wx.ALIGN_CENTER_VERTICAL | wx.ALIGN_RIGHT | wx.EXPAND)
+            var_grid.Add(wx.StaticText(self, label=f'{cfg}:'), 1, wx.ALIGN_CENTRE_VERTICAL | wx.ALIGN_RIGHT | wx.EXPAND)
             var_grid.Add(self.choices[cfg], 0, wx.EXPAND)
 
         var_box_sizer.Add(var_grid, 1, wx.EXPAND | wx.ALL, 6)
@@ -496,7 +499,7 @@ class VariantDialog(wx.Dialog):
         # opt_box_sizer.Add(checkbox_excl_from_bom, 0, wx.EXPAND | wx.ALL, 4)
         # opt_box_sizer.Add(checkbox_excl_from_pos, 0, wx.EXPAND | wx.ALL, 4)
         # opt_box_sizer.Add(wx.StaticText(self, label=''), 1, wx.EXPAND | wx.ALL)
-        # opt_box_sizer.Add(reset_button, 0, wx.ALIGN_CENTER_HORIZONTAL | wx.ALL, 4)
+        # opt_box_sizer.Add(reset_button, 0, wx.ALIGN_CENTRE_HORIZONTAL | wx.ALL, 4)
         # opt_box_sizer.Add(wx.StaticText(self, label=''), 1, wx.EXPAND | wx.ALL)
         # sel_grid.Add(opt_box_sizer, 0, wx.EXPAND | wx.ALL, 4)
 
@@ -507,15 +510,17 @@ class VariantDialog(wx.Dialog):
         self.changes_box_sizer = wx.StaticBoxSizer(changes_box)
         self.changes_box_sizer.SetMinSize((640, 280))
 
-        self.changes_text_win = wx.ScrolledWindow(self, wx.ID_ANY)
-        self.changes_text = wx.TextCtrl(self.changes_text_win, wx.ID_ANY, style=wx.BORDER_NONE | wx.TE_MULTILINE | wx.TE_READONLY | wx.TE_DONTWRAP)
-        self.update_text()
+        self.changes_list_win = wx.ScrolledWindow(self, wx.ID_ANY)
+        self.changes_list_win = wx.ScrolledWindow(self, wx.ID_ANY)
+        self.changes_list = PcbItemListBox(self.changes_list_win, board)
+
+        self.update_list()
 
         text_sizer = wx.BoxSizer(wx.VERTICAL)
-        text_sizer.Add(self.changes_text, 1, wx.EXPAND | wx.ALL, 3)
+        text_sizer.Add(self.changes_list, 1, wx.EXPAND | wx.ALL, 3)
 
-        self.changes_text_win.SetSizer(text_sizer)
-        self.changes_box_sizer.Add(self.changes_text_win, 1, wx.EXPAND | wx.ALL)
+        self.changes_list_win.SetSizer(text_sizer)
+        self.changes_box_sizer.Add(self.changes_list_win, 1, wx.EXPAND | wx.ALL)
 
         sizer.Add(self.changes_box_sizer, 1, wx.EXPAND | wx.ALL, 8)
 
@@ -536,7 +541,7 @@ class VariantDialog(wx.Dialog):
         # TODO avoid 50/50 split between boxes. should be dynamic!
 
         self.Fit()
-        self.CenterOnParent()
+        self.CentreOnParent()
 
         ok_button.Bind(wx.EVT_BUTTON, self.on_ok)
 #        update_button.Bind(wx.EVT_BUTTON, self.on_update)
@@ -558,7 +563,7 @@ class VariantDialog(wx.Dialog):
         self.Destroy()
 
     def on_change(self, event):
-        self.update_text()
+        self.update_list()
 
 #    def on_update(self, event):
 #        self.update_text()
@@ -566,34 +571,90 @@ class VariantDialog(wx.Dialog):
     def on_cancel(self, event):
         self.Destroy()
 
-    def update_text(self):
+    def update_list(self):
         changes = apply_choices(self.board, self.vn_dict, self.selections(), True)
-        change_text = '\n'.join(changes)
-        self.changes_text.SetValue(change_text)
+        self.changes_list.setItemList(changes)
 
-def ShowErrorDialog(title, errors):
-    dialog = TextDialog(f'KiVar {version()}: {title}', '\n'.join(errors))
+def ShowMissingRulesDialog():
+    dialog = MissingRulesDialog()
     dialog.ShowModal()
     dialog.Destroy()
 
-class TextDialog(wx.Dialog):
-    def __init__(self, title, text):
-        super(TextDialog, self).__init__(pcbnew_parent_window(), title=title, style=wx.DEFAULT_DIALOG_STYLE | wx.RESIZE_BORDER, size=(800, 500))
+class MissingRulesDialog(wx.Dialog):
+    def __init__(self):
+        super().__init__(pcbnew_parent_window(), title=f'KiVar {version()}: No rule definitions found', style=wx.DEFAULT_DIALOG_STYLE)
 
-        text_win = wx.ScrolledWindow(self, wx.ID_ANY)
-        self.text = wx.TextCtrl(text_win, wx.ID_ANY, style=wx.TE_MULTILINE | wx.TE_READONLY | wx.TE_DONTWRAP)
-        self.text.SetValue(text)
+        sizer = wx.BoxSizer(wx.VERTICAL)
+
+        sizer.Add(wx.StaticText(self, label='Please consult the KiVar documentation to learn how to\nassign variation rules to symbols/footprints:'), 0, wx.ALL, 10)
+
+        sizer.AddSpacer(15)
+
+        link = hyperlink.HyperLinkCtrl(self, -1, help_url(), URL='')
+        default_color = wx.Colour()
+        link.SetColours(link=default_color, visited=default_color)
+        link.SetToolTip('')
+        link.EnableRollover(False)
+        sizer.Add(link, 0, wx.ALIGN_CENTRE, wx.ALL, 10)
+
+        sizer.AddSpacer(15)
+
+        button_sizer = wx.BoxSizer(wx.HORIZONTAL)
+        ok_button = wx.Button(self, wx.ID_OK, 'Close')
+        button_sizer.Add(ok_button, 0, wx.ALIGN_CENTRE | wx.ALL, 10)
+
+        sizer.Add(button_sizer, 0, wx.ALIGN_CENTRE | wx.ALL)
+        ok_button.SetFocus()
+
+        self.SetSizerAndFit(sizer)
+
+def ShowErrorDialog(title, errors, board = None):
+    dialog = PcbItemListDialog(f'KiVar {version()}: {title}', errors, board)
+    dialog.ShowModal()
+    dialog.Destroy()
+
+class PcbItemListBox(wx.ListBox):
+    def __init__(self, parent, board = None):
+        super().__init__(parent)
+        self.board = board
+        self.refs = []
+        self.Bind(wx.EVT_LISTBOX, self.onListItemSelected)
+
+    def setItemList(self, itemlist):
+        # current selection gets reset automatically
+        self.refs = []
+        self.Clear()
+        for item in itemlist:
+            self.refs.append(item[0])
+            self.Append(item[1])
+
+    def onListItemSelected(self, event):
+        if self.board is not None:
+            ref = self.refs[self.GetSelection()]
+            if ref is not None:
+                fp = self.board.FindFootprintByReference(ref)
+                if fp is not None:
+                    wrap_FocusOnItem(fp)
+
+class PcbItemListDialog(wx.Dialog):
+    def __init__(self, title, itemlist, board = None):
+        super().__init__(pcbnew_parent_window(), title=title, style=wx.DEFAULT_DIALOG_STYLE | wx.RESIZE_BORDER, size=(800, 500))
+        self.refs = []
+
+        list_win = wx.ScrolledWindow(self, wx.ID_ANY)
+        listbox = PcbItemListBox(self, board)
+        listbox.setItemList(itemlist)
 
         scr_win_sizer = wx.BoxSizer(wx.VERTICAL)
-        scr_win_sizer.Add(self.text, 1, wx.EXPAND | wx.ALL)
-        text_win.SetSizer(scr_win_sizer)
+        scr_win_sizer.Add(listbox, 1, wx.EXPAND | wx.ALL)
+        list_win.SetSizer(scr_win_sizer)
 
-        self.ok_button = wx.Button(self, wx.ID_OK, 'Dismiss')
+        self.ok_button = wx.Button(self, wx.ID_OK, 'Close')
         button_sizer = wx.BoxSizer(wx.HORIZONTAL)
         button_sizer.Add(self.ok_button, 0, wx.ALIGN_RIGHT | wx.ALL, 8)
 
         sizer = wx.BoxSizer(wx.VERTICAL)
-        sizer.Add(text_win, 1, wx.EXPAND | wx.ALL, 8)
+        sizer.Add(list_win, 1, wx.EXPAND | wx.ALL, 8)
         sizer.Add(button_sizer, 0, wx.ALIGN_RIGHT | wx.ALL)
         self.SetSizer(sizer)
 

--- a/plugin/kivar.py
+++ b/plugin/kivar.py
@@ -60,7 +60,7 @@ def pcbnew_parent_window():
     return wx.FindWindowByName('PcbFrame')
 
 def version():
-    return '0.0.3'
+    return '0.0.4-pre1'
 
 def variant_cfg_field_name():
     return 'KiVar.Rule'

--- a/plugin/kivar.py
+++ b/plugin/kivar.py
@@ -8,14 +8,14 @@ from os import path as os_path
 
 # TODO:
 #
-# * Use None where applicable (instead of empty string)
+# * Add a Setup plugin (separate button) that defines DNP->NoPos/NoBom behavior. Having this in a separate dialog (which
+#   also takes care of nonvolatile storage of the settings) removes any dynamic reload/refresh requirements.
+#   (Setup plugin shall have similar icon with wrench in the foreground.)
 #
-# * Add options panel incl. "Reset" button, that preselects all choices depending on options (because preselect
-#   criteria depend on these checkbox states).
+# * Setup plugin: Save option settings as some object in PCB (text box?)
 #
 # * After applying configuration, define board variables containing the choice for each vn, e.g. ${KIVAR.BOOT_SEL} => NAND
 #
-# * Save option settings as some object in PCB (text box?)
 
 class VariantPlugin(pcbnew.ActionPlugin):
     def defaults(self):
@@ -181,6 +181,8 @@ def detect_current_choices(board, vn_dict):
                     selection[vn] = ''
 
     return selection
+
+# TODO check each '' or "" and use None, if applicable
 
 def apply_choices(board, vn_dict, selection, dry_run = False):
     changes = []


### PR DESCRIPTION
In lists with pending actions or rule errors, rows can now be clicked to focus the corresponding part in the PCB canvas (only KiCad 7 Nightlies).
Rewrote the dialog for missing rules, adding a hyperlink to the documentation.