### PR TITLE
Allow for some flexibility in the kivar field base

### DIFF
--- a/source/kivar_engine.py
+++ b/source/kivar_engine.py
@@ -578,9 +578,9 @@ def determine_fieldID_base(fpdict):
     # looking for any component which has a field with one of the 
     # available field options as the base
     # first non-empty one found wins
-    for uuid in fpdict:
-        fpdict_uuid_branch = fpdict[uuid]
-        for base in FieldIDOptions:
+    for base in FieldIDOptions:
+        for uuid in fpdict:
+            fpdict_uuid_branch = fpdict[uuid]
             for fp_field in fpdict_uuid_branch[Key.FIELDS]:
                 value = fpdict_uuid_branch[Key.FIELDS][fp_field]
                 if value is None or not len(value):


### PR DESCRIPTION
I have been using a similar, home-grown, system for some time but have moved to KiVar (nice work!).

My issue was the choice of "Var" for the field.  It's fine, and nice and short, but 

  * "var" can mean many things (especially to programmers, heh); and 
  
  * I was and like to use "Variant"
  
  * I think it would be cool to support Variant and other options (e.g. Config or Build)
  
and so, the proposed patch.  

This automatically lets you choose any one of the supported bases on a per-project basis and auto-detects whichever was selected, without impacting any of the other functionality. 

Making this PR in the hopes you find it worthy of inclusion, please don't hesitate if you have questions or modifications to propose.  Thanks.  